### PR TITLE
Refactor force calculation

### DIFF
--- a/src/sim/physics.rs
+++ b/src/sim/physics.rs
@@ -57,17 +57,14 @@ impl PhysicsContext {
             let mut force = Vec2::ZERO;
             for other in &self.bodies {
                 if body != other {
-                    let sqr_dist = (other.position(self) - body.position(self))
-                        .length_squared();
-                    let force_dir = (other.position(self)
-                        - body.position(self))
-                    .normalize();
-                    force += force_dir
+                    let dir = other.position(self) - body.position(self);
+                    let sqr_dist = dir.length_squared();
+                    force += dir
                         * UNIVERSAL_GRAVITY
                         * GRAVITY_AMPLIFIER
                         * body.mass(self)
                         * other.mass(self)
-                        / sqr_dist;
+                        / (sqr_dist * sqr_dist.sqrt());
                 }
             }
 


### PR DESCRIPTION
Leads to slight performance improvements (upwards of 10%).

The normalize function returns the vector divided by its length:
`let normalized = self.mul(self.length_recip());`
We can have that operation directly in the force calculation without having to call normalize, since we need the length squared anyway.
I'm no expert but my guess is that since we call length_squared(), then normalize() which calls length_recip() which calls length(), we basically do the dot() operations twice because they both call it. I would assume this would be optimized by the compiler but it's the only explanation I could come up with.

Anyway, run on my PC in release mode with 500 bodies, my FPS count increases from 20 to 30 fps.