### PR TITLE
Use Particular for gravitational interaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ glam = "0.21.3"
 bytemuck = { version = "1.11.0", features = [ "derive" ] }
 js-sys = "0.3.59"
 nalgebra = { version = "0.31.1" , features = ["convert-glam021"] }
+particular = "0.1.6"
 
 [dependencies.rapier2d]
 version = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ wgpu = { version = "0.13.1", features = ["webgl"] } # TODO: Years in the future 
 glam = "0.21.3"
 bytemuck = { version = "1.11.0", features = [ "derive" ] }
 js-sys = "0.3.59"
-nalgebra = { version = "0.31.1" , features = ["convert-glam021"] }
-particular = "0.1.6"
+nalgebra = { version = "0.31.1", features = ["convert-glam021"] }
+particular = "0.2.0"
 
 [dependencies.rapier2d]
 version = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,25 +21,26 @@ crate-type = ["cdylib"]
 
 [dependencies]
 console_error_panic_hook = "0.1.7"
-wasm-bindgen = "0.2.82"
-wasm-bindgen-futures = "0.4.32"
+wasm-bindgen = "0.2.83"
+wasm-bindgen-futures = "0.4.33"
 raw-window-handle = "0.5.0"
-winit = "0.27.1"
-gloo-console = "0.2.1"
+winit = "0.27.3"
+gloo-console = "0.2.3"
 instant = "0.1.12"
 wgpu = { version = "0.13.1", features = ["webgl"] } # TODO: Years in the future when wgpu is stable, remove gl
 glam = "0.21.3"
-bytemuck = { version = "1.11.0", features = [ "derive" ] }
-js-sys = "0.3.59"
+bytemuck = { version = "1.12.1", features = [ "derive" ] }
+js-sys = "0.3.60"
 nalgebra = { version = "0.31.1", features = ["convert-glam021"] }
 particular = "0.2.0"
+
 
 [dependencies.rapier2d]
 version = "0.14.0"
 features = [ "wasm-bindgen"]
 
 [dependencies.web-sys]
-version = "0.3.59"
+version = "0.3.60"
 features = [
     'Document',
     'Element',
@@ -50,6 +51,6 @@ features = [
 ]
 
 [dependencies.image]
-version = "0.24.3"
+version = "0.24.4"
 default-features = false
 features = ["png", "jpeg"]

--- a/src/render/frame_descriptor.rs
+++ b/src/render/frame_descriptor.rs
@@ -23,7 +23,7 @@ pub struct FrameDescriptor {
 impl FrameDescriptor {
     pub fn build(sim: &Simulation) -> FrameDescriptor {
         let mut transforms = Vec::new();
-        for body in &sim.physics_context.bodies.particles {
+        for body in sim.physics_context.bodies.iter() {
             transforms.push(GpuTransform {
                 model: Mat4::from_scale_rotation_translation(
                     Vec2::splat(2.0 * body.radius()).extend(1.0),

--- a/src/sim/body.rs
+++ b/src/sim/body.rs
@@ -1,4 +1,4 @@
-use glam::{Vec2, Vec3};
+use glam::Vec2;
 use particular::prelude::Particle;
 use rapier2d::prelude::*;
 
@@ -15,8 +15,10 @@ pub struct Body {
 }
 
 impl Particle for Body {
-    fn position(&self) -> Vec3 {
-        self.position.extend(0.0)
+    type Vector = Vec2;
+
+    fn position(&self) -> Vec2 {
+        self.position
     }
 
     fn mu(&self) -> f32 {
@@ -71,7 +73,7 @@ impl Body {
     pub fn apply_acceleration_to_rigidbody(
         &self,
         bodies: &mut RigidBodySet,
-        acceleration: Vec2,
+        acceleration: <Self as Particle>::Vector,
     ) {
         let rb = bodies.get_mut(self.rigidbody_handle).unwrap();
         let force = acceleration * self.mass();

--- a/src/sim/physics.rs
+++ b/src/sim/physics.rs
@@ -1,9 +1,10 @@
+use particular::ParticleSet;
 use rapier2d::prelude::*;
 
-use super::body::{Body, BodySet};
+use super::body::Body;
 
 pub struct PhysicsContext {
-    pub bodies: BodySet,
+    pub bodies: ParticleSet<Body>,
     pub integration_parameters: IntegrationParameters,
     pub physics_pipeline: PhysicsPipeline,
     pub island_manager: IslandManager,
@@ -17,7 +18,7 @@ pub struct PhysicsContext {
 impl PhysicsContext {
     pub fn new() -> Self {
         Self {
-            bodies: BodySet::new(),
+            bodies: ParticleSet::<Body>::new(),
             integration_parameters: IntegrationParameters::default(),
             physics_pipeline: PhysicsPipeline::new(),
             island_manager: IslandManager::new(),
@@ -44,39 +45,34 @@ impl PhysicsContext {
         let mut particle = Body::new(rigid_body_handle, collider_handle);
         particle.sync_to_rigidbody(&self.rigid_body_set, &self.collider_set);
 
-        self.bodies.particles.push(particle);
+        self.bodies.add(particle);
     }
 
     pub fn step(&mut self) {
-        self.bodies.response(|mut result| {
-            for (particle, acceleration) in &result {
-                particle.apply_force_to_rigidbody(
-                    &mut self.rigid_body_set,
-                    *acceleration * particle.mass(),
-                )
-            }
-
-            self.physics_pipeline.step(
-                &vector![0.0, 0.0],
-                &self.integration_parameters,
-                &mut self.island_manager,
-                &mut self.broad_phase,
-                &mut self.narrow_phase,
+        for (body, acceleration) in self.bodies.result() {
+            body.apply_acceleration_to_rigidbody(
                 &mut self.rigid_body_set,
-                &mut self.collider_set,
-                &mut ImpulseJointSet::new(),
-                &mut MultibodyJointSet::new(),
-                &mut self.ccd_solver,
-                &(),
-                &(),
-            );
+                acceleration.truncate(),
+            )
+        }
 
-            for (particle, _) in &mut result {
-                particle.sync_to_rigidbody(
-                    &self.rigid_body_set,
-                    &self.collider_set,
-                );
-            }
-        });
+        self.physics_pipeline.step(
+            &vector![0.0, 0.0],
+            &self.integration_parameters,
+            &mut self.island_manager,
+            &mut self.broad_phase,
+            &mut self.narrow_phase,
+            &mut self.rigid_body_set,
+            &mut self.collider_set,
+            &mut ImpulseJointSet::new(),
+            &mut MultibodyJointSet::new(),
+            &mut self.ccd_solver,
+            &(),
+            &(),
+        );
+
+        for body in self.bodies.iter_mut() {
+            body.sync_to_rigidbody(&self.rigid_body_set, &self.collider_set);
+        }
     }
 }

--- a/src/sim/physics.rs
+++ b/src/sim/physics.rs
@@ -52,7 +52,7 @@ impl PhysicsContext {
         for (body, acceleration) in self.bodies.result() {
             body.apply_acceleration_to_rigidbody(
                 &mut self.rigid_body_set,
-                acceleration.truncate(),
+                acceleration,
             )
         }
 


### PR DESCRIPTION
Since Particular 0.2.0 is also generic over its position type, we can use glam's Vec2 instead of Vec3 to describe a body's position. I decided not to use nalgebra directly to describe the position as it results in worse performance.

Next PR will hopefully be compute shaders, although I don't know how long that will take me. I was slowed down significantly by rust-lang/rust#102274 which forces me to reconsider some implementation details but I will eventually work it out.